### PR TITLE
Give warning before kill by touching a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ gclog
 .tox
 *__pycache__
 *.pyc
+
+# core files
+core

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -1,13 +1,12 @@
 import os
-import resource
 
 from plumbum import local
 import pytest
 
 
 CHECK_CORES = os.environ.get('CHECK_CORES', '') != ''
-JAVA_HOME=os.environ.get('JAVA_HOME')
-assert JAVA_HOME != None
+JAVA_HOME = os.environ.get('JAVA_HOME')
+assert JAVA_HOME is not None
 
 java_cmd = local["{0}/bin/java".format(JAVA_HOME)]
 agent_path = "-agentpath:{0}/libjvmquake.so".format(os.getcwd())

--- a/tests/test_basic_ooms.py
+++ b/tests/test_basic_ooms.py
@@ -1,6 +1,13 @@
+import pytest
 from pathlib import Path
 
-from environment import *
+from environment import agent_path
+from environment import assert_files
+from environment import CHECK_CORES
+from environment import class_path
+from environment import cleanup
+from environment import core_ulimit
+from environment import java_cmd
 
 
 @pytest.fixture()

--- a/tests/test_hard_ooms.py
+++ b/tests/test_hard_ooms.py
@@ -116,3 +116,73 @@ def test_jvmquake_cms_slow_death_core(core_ulimit):
         assert not heapdump_path.is_file()
     finally:
         cleanup(*files)
+
+
+def test_jvmquake_cms_touch_warning():
+    """
+    Executes a program which over time does way more GC than actual execution
+    Then test that jvmquake correctly touches the correct file
+    """
+    jvmquake_warn_path = Path('/tmp/jvmquake_warn_gc')
+    files = [jvmquake_warn_path]
+    cleanup(*files)
+
+    start_time = time.time()
+
+    cms_slow_death_warn_only = java_cmd[
+        '-Xmx100m',
+        '-XX:+UseParNewGC',
+        '-XX:+UseConcMarkSweepGC',
+        '-XX:CMSInitiatingOccupancyFraction=75',
+        agent_path + "=3,1,9,warn=1",
+        '-cp', class_path,
+        'SlowDeathOOM'
+    ]
+
+    print("Executing Complex CMS Slow Death OOM")
+    print("[{0}]".format(cms_slow_death_warn_only))
+    with cms_slow_death_warn_only.bgrun(retcode=-9, timeout=10) as proc:
+        pid = proc.pid
+
+    print("Ran pid {}".format(pid))
+    try:
+        assert_files(*files)
+        mtime = os.path.getmtime(str(jvmquake_warn_path))
+        assert mtime > (start_time + 1)
+    finally:
+        cleanup(*files)
+
+
+def test_jvmquake_cms_touch_warning_custom_path():
+    """
+    Executes a program which over time does way more GC than actual execution
+    Then test that jvmquake correctly touches the correct file
+    """
+    jvmquake_warn_path = Path('/tmp/jvmquake_custom_path')
+    files = [jvmquake_warn_path]
+    cleanup(*files)
+
+    start_time = time.time()
+
+    cms_slow_death_warn_only = java_cmd[
+        '-Xmx100m',
+        '-XX:+UseParNewGC',
+        '-XX:+UseConcMarkSweepGC',
+        '-XX:CMSInitiatingOccupancyFraction=75',
+        agent_path + "=5,1,9,warn=2,touch=" + str(jvmquake_warn_path),
+        '-cp', class_path,
+        'SlowDeathOOM'
+    ]
+
+    print("Executing Complex CMS Slow Death OOM")
+    print("[{0}]".format(cms_slow_death_warn_only))
+    with cms_slow_death_warn_only.bgrun(retcode=-9, timeout=20) as proc:
+        pid = proc.pid
+
+    print("Ran pid {}".format(pid))
+    try:
+        assert_files(*files)
+        mtime = os.path.getmtime(str(jvmquake_warn_path))
+        assert mtime > (start_time + 2)
+    finally:
+        cleanup(*files)

--- a/tests/test_hard_ooms.py
+++ b/tests/test_hard_ooms.py
@@ -1,6 +1,15 @@
+import os
+import time
+
 from pathlib import Path
 
-from environment import *
+from environment import agent_path
+from environment import assert_files
+from environment import CHECK_CORES
+from environment import class_path
+from environment import cleanup
+from environment import core_ulimit
+from environment import java_cmd
 
 
 def test_jvmquake_cms_slow_death_oom():

--- a/tests/test_java_opts.py
+++ b/tests/test_java_opts.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
 import plumbum
+import pytest
 
-from environment import *
+from environment import assert_files
+from environment import class_path
+from environment import cleanup
+from environment import java_cmd
 
 
 @pytest.fixture()

--- a/tests/test_non_ooms.py
+++ b/tests/test_non_ooms.py
@@ -1,11 +1,11 @@
-import os
-
-from environment import *
+from environment import agent_path
+from environment import class_path
+from environment import java_cmd
 
 
 def test_jvmquake_healthy_jvm():
     """
-    Executes a program which should work and exit after 20 seconds
+    Executes a program which should work and exit after 10 seconds
     """
     easy_oom = java_cmd[
         '-Xmx10m',
@@ -16,4 +16,3 @@ def test_jvmquake_healthy_jvm():
     print("Executing NON-OOM program")
     print("[{0}]".format(easy_oom))
     easy_oom.run(retcode=0, timeout=15)
-


### PR DESCRIPTION
I had a feature request for adding support for signaling another process or supervisor when `jvmquake` detects that things are going sideways but _before_ it actually kills the process. Since we're running along side the JVM in a compiled JVMTI agent our limits are somewhat limited, we can:
1. Signal the JVM
2. Signal another process (but it would have to be passed at startup time)
3. Touch a file on the filesystem
4. Fork + exec some executable (probably with a double fork to background it).

I chose to go with option 3 since that is, in my opinion, the simplest and safest option. Then if a user wants to e.g. obtain a CPU profile of the JVM they can watch for updates to the file and run whatever logic they want to get more diagnostic information.

I've added a fourth option, which is a string option containing arbitrary key=value pairs (e.g. `key1=value1,key2=value2` so that in the future we can extend the arguments supported by jvmquake. In this PR we now support two new kwargs:
* `warn`: Similar to gc_threshold except will trigger the warning mechanism
* `touch`: The file path to touch when the `warn` threshold is exceeded.

I've also added a few tests, and done some refactoring of the tests to be slightly cleaner.